### PR TITLE
Changed Stats.LastTimeActive type from [TimeSpan] to [DateTime]

### DIFF
--- a/Core.ps1
+++ b/Core.ps1
@@ -644,7 +644,7 @@ while ($Quit -eq $false) {
                             $Stats = [PSCustomObject]@{
                                 BestTimes        = 0
                                 BenchmarkedTimes = 0
-                                LastTimeActive   = [TimeSpan]0
+                                LastTimeActive   = [DateTime]0
                                 ActivatedTimes   = 0
                                 ActiveTime       = [TimeSpan]0
                                 FailedTimes      = 0


### PR DESCRIPTION
Stats.LastTimeActive is compared to (Get-Date), which is of type System.DateTime, not System.TimeSpan.